### PR TITLE
fix: harden cross-platform local entrypoints

### DIFF
--- a/.github/workflows/windows-local-entrypoints.yml
+++ b/.github/workflows/windows-local-entrypoints.yml
@@ -1,0 +1,58 @@
+name: Windows Local Entrypoint Validation
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/windows-local-entrypoints.yml"
+      - "scripts/ci/verify_windows_entrypoints.ps1"
+      - "setup_env.ps1"
+      - "setup_env.bat"
+      - "start_dashboard.ps1"
+      - "start_dashboard.bat"
+      - "pyproject.toml"
+      - "tests/test_local_entrypoint_contracts.py"
+      - "apps/dashboard/frontend/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-local-entrypoints-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-entrypoints:
+    name: PowerShell and dashboard readback
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      MTEL_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - name: Check out the exact pull-request head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
+
+      - name: Configure Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Execute Windows entrypoint runtime readback
+        shell: pwsh
+        run: |
+          $artifactDirectory = Join-Path "${{ runner.temp }}" "windows-entrypoint-readback"
+          .\scripts\ci\verify_windows_entrypoints.ps1 -ArtifactDirectory $artifactDirectory
+
+      - name: Upload Windows entrypoint readback
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-entrypoint-readback-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/windows-entrypoint-readback
+          if-no-files-found: error
+          retention-days: 14

--- a/install.sh
+++ b/install.sh
@@ -1,55 +1,83 @@
-#!/bin/bash
-# ToneSoul Installation Script for Linux/macOS
-# Usage: curl -sSL https://raw.githubusercontent.com/Fan1234-1/tonesoul52/master/install.sh | bash
+#!/usr/bin/env bash
+# ToneSoul installation helper for Linux/macOS.
+# Run from a local repository checkout: bash install.sh
 
-set -e
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
 
 echo "🌌 ToneSoul Installer"
 echo "====================="
+echo "Repository root: $SCRIPT_DIR"
 echo ""
 
-# Check Python version
-PYTHON_CMD=""
-if command -v python3 &> /dev/null; then
-    PYTHON_VERSION=$(python3 -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
-    MAJOR=$(echo $PYTHON_VERSION | cut -d. -f1)
-    MINOR=$(echo $PYTHON_VERSION | cut -d. -f2)
-    if [ "$MAJOR" -ge 3 ] && [ "$MINOR" -ge 10 ]; then
-        PYTHON_CMD="python3"
-    fi
+if [[ ! -f "pyproject.toml" || ! -d "tonesoul" ]]; then
+    echo "❌ Error: install.sh must run from a complete ToneSoul checkout."
+    echo "   Missing pyproject.toml or tonesoul/."
+    exit 1
 fi
 
-if [ -z "$PYTHON_CMD" ]; then
-    echo "❌ Error: Python 3.10+ is required"
+PYTHON_CMD=""
+for candidate in python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1 \
+        && "$candidate" -c \
+            'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'; then
+        PYTHON_CMD="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$PYTHON_CMD" ]]; then
+    echo "❌ Error: Python 3.10+ is required."
     echo "   Please install Python 3.10 or later from https://python.org"
     exit 1
 fi
 
 echo "✅ Found Python: $($PYTHON_CMD --version)"
 
-# Create virtual environment
-echo ""
-echo "📦 Creating virtual environment..."
-$PYTHON_CMD -m venv .venv
+if [[ ! -x ".venv/bin/python" ]]; then
+    echo ""
+    echo "📦 Creating virtual environment..."
+    "$PYTHON_CMD" -m venv .venv
+else
+    echo ""
+    echo "📦 Existing .venv found. Re-using it."
+fi
 
-# Activate virtual environment
-source .venv/bin/activate
+VENV_PYTHON="$SCRIPT_DIR/.venv/bin/python"
 
-# Install ToneSoul
 echo ""
-echo "📥 Installing ToneSoul..."
-pip install --upgrade pip
-pip install -e ".[dev]"
+echo "📥 Installing ToneSoul from pyproject.toml..."
+"$VENV_PYTHON" -m pip install --upgrade pip
+"$VENV_PYTHON" -m pip install -e ".[dev]"
 
-# Verify installation
 echo ""
-echo "🔍 Verifying installation..."
-python -c "import tonesoul; print(f'ToneSoul version: {tonesoul.__version__}')" 2>/dev/null || echo "ToneSoul core installed"
+echo "🔍 Verifying package and distribution versions..."
+"$VENV_PYTHON" - <<'PY'
+from importlib.metadata import version
 
-# Run 7D verification
+import tonesoul
+
+installed_version = version("tonesoul52")
+package_version = tonesoul.__version__
+if installed_version != package_version:
+    raise SystemExit(
+        "ToneSoul version mismatch: "
+        f"package={package_version}, distribution={installed_version}"
+    )
+print(f"ToneSoul version: {package_version}")
+PY
+
 echo ""
-echo "🎯 Running 7D Audit..."
-python scripts/verify_7d.py --json 2>/dev/null || echo "7D verification available via: python scripts/verify_7d.py"
+echo "🎯 Running 7D audit..."
+if [[ -f "scripts/verify_7d.py" ]]; then
+    if ! "$VENV_PYTHON" scripts/verify_7d.py --json; then
+        echo "⚠️  7D audit did not pass. Installation succeeded, but governance verification needs review."
+    fi
+else
+    echo "⚠️  scripts/verify_7d.py is not present in this checkout."
+fi
 
 echo ""
 echo "✨ Installation complete!"
@@ -58,7 +86,7 @@ echo "To activate the environment:"
 echo "  source .venv/bin/activate"
 echo ""
 echo "To run tests:"
-echo "  pytest"
+echo "  python -m pytest"
 echo ""
-echo "To run 7D audit:"
+echo "To run the 7D audit:"
 echo "  python scripts/verify_7d.py"

--- a/scripts/ci/verify_windows_entrypoints.ps1
+++ b/scripts/ci/verify_windows_entrypoints.ps1
@@ -27,12 +27,18 @@ $VenvPython = Join-Path $VenvDir "Scripts\python.exe"
 $AppPath = Join-Path $RepoRoot "apps\dashboard\frontend\app.py"
 $WindowsPowerShell = (Get-Command powershell.exe -ErrorAction Stop).Source
 $BasePython = (Get-Command python.exe -ErrorAction Stop).Source
+$CommitSha = if (-not [string]::IsNullOrWhiteSpace($env:MTEL_HEAD_SHA)) {
+    $env:MTEL_HEAD_SHA
+}
+else {
+    $env:GITHUB_SHA
+}
 
 $Summary = [ordered]@{
     schema_version = "1.0"
     status = "running"
     repository_root = $RepoRoot
-    commit = $env:GITHUB_SHA
+    commit = $CommitSha
     runner_os = $env:RUNNER_OS
     harness_powershell = $PSVersionTable.PSVersion.ToString()
     windows_powershell = $null
@@ -111,6 +117,35 @@ function Invoke-LauncherExpectedFailure {
     return $Result
 }
 
+function Stop-DashboardProcessTree {
+    param(
+        [Parameter(Mandatory = $true)][System.Diagnostics.Process]$Process
+    )
+
+    try {
+        $Process.Refresh()
+        if (-not $Process.HasExited) {
+            $Taskkill = (Get-Command taskkill.exe -ErrorAction Stop).Source
+            $TaskkillResult = Invoke-CapturedCommand -Name "dashboard-process-tree-stop" -FilePath $Taskkill -Arguments @(
+                "/PID", [string]$Process.Id,
+                "/T",
+                "/F"
+            )
+            if ($TaskkillResult.ExitCode -ne 0) {
+                Write-Warning "taskkill returned exit code $($TaskkillResult.ExitCode)."
+            }
+        }
+
+        $null = $Process.WaitForExit(15000)
+        $Process.Refresh()
+        return $Process.HasExited
+    }
+    catch {
+        Write-Warning "Unable to confirm dashboard process cleanup: $($_.Exception.Message)"
+        return $false
+    }
+}
+
 $DashboardProcess = $null
 $DashboardStdout = Join-Path $ArtifactDirectory "dashboard.stdout.log"
 $DashboardStderr = Join-Path $ArtifactDirectory "dashboard.stderr.log"
@@ -123,7 +158,7 @@ try {
     $WindowsPowerShellVersion = Invoke-CapturedCommand -Name "windows-powershell-version" -FilePath $WindowsPowerShell -Arguments @(
         "-NoLogo",
         "-NoProfile",
-        "-Command", "$PSVersionTable.PSVersion.ToString()"
+        "-Command", '$PSVersionTable.PSVersion.ToString()'
     )
     Assert-True -Condition ($WindowsPowerShellVersion.ExitCode -eq 0) -Message "Unable to read Windows PowerShell version."
     $Summary["windows_powershell"] = $WindowsPowerShellVersion.OutputText.Trim()
@@ -226,92 +261,75 @@ try {
         "-NoLogo",
         "-NoProfile",
         "-ExecutionPolicy", "Bypass",
-        "-File", $LauncherPath
+        "-File", ('"{0}"' -f $LauncherPath)
     ) -WorkingDirectory $RepoRoot -RedirectStandardOutput $DashboardStdout -RedirectStandardError $DashboardStderr -WindowStyle Hidden -PassThru
 
     $Summary["dashboard_process_started"] = $true
     Write-Host "[CI] Dashboard launcher PID: $($DashboardProcess.Id)"
 
-    $HealthUri = "http://127.0.0.1:8501/_stcore/health"
-    $RootUri = "http://127.0.0.1:8501/"
-    $Deadline = [DateTime]::UtcNow.AddSeconds(90)
-    $HealthResponse = $null
+    try {
+        $HealthUri = "http://127.0.0.1:8501/_stcore/health"
+        $RootUri = "http://127.0.0.1:8501/"
+        $Deadline = [DateTime]::UtcNow.AddSeconds(90)
+        $HealthResponse = $null
 
-    while ([DateTime]::UtcNow -lt $Deadline) {
-        $DashboardProcess.Refresh()
-        if ($DashboardProcess.HasExited) {
-            break
-        }
-
-        try {
-            $HealthResponse = Invoke-WebRequest -Uri $HealthUri -TimeoutSec 5
-            if ($HealthResponse.StatusCode -eq 200) {
+        while ([DateTime]::UtcNow -lt $Deadline) {
+            $DashboardProcess.Refresh()
+            if ($DashboardProcess.HasExited) {
                 break
             }
+
+            try {
+                $HealthResponse = Invoke-WebRequest -Uri $HealthUri -TimeoutSec 5
+                if ($HealthResponse.StatusCode -eq 200) {
+                    break
+                }
+            }
+            catch {
+                Start-Sleep -Seconds 2
+            }
         }
-        catch {
-            Start-Sleep -Seconds 2
+
+        $DashboardProcess.Refresh()
+        if ($null -eq $HealthResponse -or $HealthResponse.StatusCode -ne 200) {
+            $StdoutText = if (Test-Path $DashboardStdout) { Get-Content -LiteralPath $DashboardStdout -Raw } else { "" }
+            $StderrText = if (Test-Path $DashboardStderr) { Get-Content -LiteralPath $DashboardStderr -Raw } else { "" }
+            throw "Dashboard health endpoint did not become ready. HasExited=$($DashboardProcess.HasExited)`nSTDOUT:`n$StdoutText`nSTDERR:`n$StderrText"
         }
+
+        $Summary["dashboard_health_status"] = [int]$HealthResponse.StatusCode
+        $Summary["dashboard_health_body"] = ([string]$HealthResponse.Content).Trim()
+
+        $RootResponse = Invoke-WebRequest -Uri $RootUri -TimeoutSec 10
+        $Summary["dashboard_root_status"] = [int]$RootResponse.StatusCode
+        Assert-True -Condition ($RootResponse.StatusCode -eq 200) -Message "Dashboard root endpoint did not return HTTP 200."
+
+        Start-Sleep -Seconds 3
+        $DashboardProcess.Refresh()
+        Assert-True -Condition (-not $DashboardProcess.HasExited) -Message "Dashboard launcher exited immediately after reporting healthy."
+
+        Write-Host "DASHBOARD_PROCESS_STARTED=YES"
+        Write-Host "DASHBOARD_HEALTH_READY=YES"
+        Write-Host "DASHBOARD_HTTP_STATUS=$($HealthResponse.StatusCode)"
+    }
+    finally {
+        $Summary["dashboard_process_stopped"] = Stop-DashboardProcessTree -Process $DashboardProcess
     }
 
-    $DashboardProcess.Refresh()
-    if ($null -eq $HealthResponse -or $HealthResponse.StatusCode -ne 200) {
-        $StdoutText = if (Test-Path $DashboardStdout) { Get-Content -LiteralPath $DashboardStdout -Raw } else { "" }
-        $StderrText = if (Test-Path $DashboardStderr) { Get-Content -LiteralPath $DashboardStderr -Raw } else { "" }
-        throw "Dashboard health endpoint did not become ready. HasExited=$($DashboardProcess.HasExited)`nSTDOUT:`n$StdoutText`nSTDERR:`n$StderrText"
-    }
-
-    $Summary["dashboard_health_status"] = [int]$HealthResponse.StatusCode
-    $Summary["dashboard_health_body"] = $HealthResponse.Content.Trim()
-
-    $RootResponse = Invoke-WebRequest -Uri $RootUri -TimeoutSec 10
-    $Summary["dashboard_root_status"] = [int]$RootResponse.StatusCode
-    Assert-True -Condition ($RootResponse.StatusCode -eq 200) -Message "Dashboard root endpoint did not return HTTP 200."
-
-    Start-Sleep -Seconds 3
-    $DashboardProcess.Refresh()
-    Assert-True -Condition (-not $DashboardProcess.HasExited) -Message "Dashboard launcher exited immediately after reporting healthy."
-
-    Write-Host "DASHBOARD_PROCESS_STARTED=YES"
-    Write-Host "DASHBOARD_HEALTH_READY=YES"
-    Write-Host "DASHBOARD_HTTP_STATUS=$($HealthResponse.StatusCode)"
+    Assert-True -Condition ([bool]$Summary["dashboard_process_stopped"]) -Message "Dashboard process tree cleanup could not be confirmed."
+    Write-Host "DASHBOARD_PROCESS_STOPPED=YES"
 
     $Summary["status"] = "passed"
 }
 catch {
     $Summary["status"] = "failed"
     $Summary["failure_message"] = $_.Exception.Message
-    Write-Error $_
+    Write-Host "[CI] Failure: $($_.Exception.Message)" -ForegroundColor Red
     throw
 }
 finally {
-    if ($null -ne $DashboardProcess) {
-        try {
-            $DashboardProcess.Refresh()
-            if (-not $DashboardProcess.HasExited) {
-                $Taskkill = (Get-Command taskkill.exe -ErrorAction Stop).Source
-                $TaskkillResult = Invoke-CapturedCommand -Name "dashboard-process-tree-stop" -FilePath $Taskkill -Arguments @(
-                    "/PID", [string]$DashboardProcess.Id,
-                    "/T",
-                    "/F"
-                )
-                if ($TaskkillResult.ExitCode -ne 0) {
-                    Write-Warning "taskkill returned exit code $($TaskkillResult.ExitCode)."
-                }
-            }
-
-            $null = $DashboardProcess.WaitForExit(15000)
-            $DashboardProcess.Refresh()
-            $Summary["dashboard_process_stopped"] = $DashboardProcess.HasExited
-        }
-        catch {
-            Write-Warning "Unable to confirm dashboard process cleanup: $($_.Exception.Message)"
-            $Summary["dashboard_process_stopped"] = $false
-        }
-    }
-
-    if ($Summary["dashboard_process_started"] -and $Summary["dashboard_process_stopped"]) {
-        Write-Host "DASHBOARD_PROCESS_STOPPED=YES"
+    if ($null -ne $DashboardProcess -and -not [bool]$Summary["dashboard_process_stopped"]) {
+        $Summary["dashboard_process_stopped"] = Stop-DashboardProcessTree -Process $DashboardProcess
     }
 
     $Summary["finished_at_utc"] = [DateTime]::UtcNow.ToString("o")

--- a/scripts/ci/verify_windows_entrypoints.ps1
+++ b/scripts/ci/verify_windows_entrypoints.ps1
@@ -1,0 +1,321 @@
+[CmdletBinding()]
+param(
+    [string]$ArtifactDirectory = ""
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+Set-Location $RepoRoot
+
+if ([string]::IsNullOrWhiteSpace($ArtifactDirectory)) {
+    if (-not [string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+        $ArtifactDirectory = Join-Path $env:RUNNER_TEMP "windows-entrypoint-readback"
+    }
+    else {
+        $ArtifactDirectory = Join-Path $RepoRoot "artifacts\windows-entrypoint-readback"
+    }
+}
+
+New-Item -ItemType Directory -Path $ArtifactDirectory -Force | Out-Null
+
+$SetupPath = Join-Path $RepoRoot "setup_env.ps1"
+$LauncherPath = Join-Path $RepoRoot "start_dashboard.ps1"
+$VenvDir = Join-Path $RepoRoot ".venv"
+$VenvPython = Join-Path $VenvDir "Scripts\python.exe"
+$AppPath = Join-Path $RepoRoot "apps\dashboard\frontend\app.py"
+$WindowsPowerShell = (Get-Command powershell.exe -ErrorAction Stop).Source
+$BasePython = (Get-Command python.exe -ErrorAction Stop).Source
+
+$Summary = [ordered]@{
+    schema_version = "1.0"
+    status = "running"
+    repository_root = $RepoRoot
+    commit = $env:GITHUB_SHA
+    runner_os = $env:RUNNER_OS
+    harness_powershell = $PSVersionTable.PSVersion.ToString()
+    windows_powershell = $null
+    base_python = $BasePython
+    venv_python_version = $null
+    setup_exit_code = $null
+    dependency_probe_exit_code = $null
+    static_contract_exit_code = $null
+    missing_venv_exit_code = $null
+    missing_app_exit_code = $null
+    missing_streamlit_exit_code = $null
+    dashboard_process_started = $false
+    dashboard_health_status = $null
+    dashboard_health_body = $null
+    dashboard_root_status = $null
+    dashboard_process_stopped = $false
+    failure_message = $null
+    started_at_utc = [DateTime]::UtcNow.ToString("o")
+    finished_at_utc = $null
+}
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory = $true)][bool]$Condition,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Invoke-CapturedCommand {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $LogPath = Join-Path $ArtifactDirectory ("{0}.log" -f $Name)
+    Write-Host "[CI] $Name"
+    Write-Host "[CI] Command: $FilePath $($Arguments -join ' ')"
+
+    $Output = @(& $FilePath @Arguments 2>&1)
+    $ExitCode = $LASTEXITCODE
+    $OutputText = ($Output | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine
+    $OutputText | Set-Content -Path $LogPath -Encoding UTF8
+
+    if (-not [string]::IsNullOrWhiteSpace($OutputText)) {
+        Write-Host $OutputText
+    }
+    Write-Host "[CI] Exit code: $ExitCode"
+
+    return [PSCustomObject]@{
+        ExitCode = $ExitCode
+        OutputText = $OutputText
+        LogPath = $LogPath
+    }
+}
+
+function Invoke-LauncherExpectedFailure {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$ExpectedText
+    )
+
+    $Result = Invoke-CapturedCommand -Name $Name -FilePath $WindowsPowerShell -Arguments @(
+        "-NoLogo",
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-File", $LauncherPath
+    )
+
+    Assert-True -Condition ($Result.ExitCode -ne 0) -Message "$Name unexpectedly returned exit code 0."
+    Assert-True -Condition ($Result.OutputText -like "*$ExpectedText*") -Message "$Name did not report the expected failure: $ExpectedText"
+    return $Result
+}
+
+$DashboardProcess = $null
+$DashboardStdout = Join-Path $ArtifactDirectory "dashboard.stdout.log"
+$DashboardStderr = Join-Path $ArtifactDirectory "dashboard.stderr.log"
+
+try {
+    Assert-True -Condition (Test-Path $SetupPath) -Message "Missing setup script: $SetupPath"
+    Assert-True -Condition (Test-Path $LauncherPath) -Message "Missing dashboard launcher: $LauncherPath"
+    Assert-True -Condition (Test-Path $AppPath) -Message "Missing dashboard app: $AppPath"
+
+    $WindowsPowerShellVersion = Invoke-CapturedCommand -Name "windows-powershell-version" -FilePath $WindowsPowerShell -Arguments @(
+        "-NoLogo",
+        "-NoProfile",
+        "-Command", "$PSVersionTable.PSVersion.ToString()"
+    )
+    Assert-True -Condition ($WindowsPowerShellVersion.ExitCode -eq 0) -Message "Unable to read Windows PowerShell version."
+    $Summary["windows_powershell"] = $WindowsPowerShellVersion.OutputText.Trim()
+
+    $SetupResult = Invoke-CapturedCommand -Name "setup-env" -FilePath $WindowsPowerShell -Arguments @(
+        "-NoLogo",
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-File", $SetupPath
+    )
+    $Summary["setup_exit_code"] = $SetupResult.ExitCode
+    Assert-True -Condition ($SetupResult.ExitCode -eq 0) -Message "setup_env.ps1 failed."
+    Assert-True -Condition (Test-Path $VenvPython) -Message "setup_env.ps1 returned success but .venv Python is missing."
+
+    $VersionResult = Invoke-CapturedCommand -Name "venv-python-version" -FilePath $VenvPython -Arguments @(
+        "-c",
+        "import sys; print('.'.join(map(str, sys.version_info[:3]))); raise SystemExit(0 if sys.version_info >= (3, 10) else 1)"
+    )
+    Assert-True -Condition ($VersionResult.ExitCode -eq 0) -Message "The generated virtual environment does not satisfy Python 3.10+."
+    $Summary["venv_python_version"] = $VersionResult.OutputText.Trim()
+
+    $DependencyResult = Invoke-CapturedCommand -Name "dashboard-dependency-probe" -FilePath $VenvPython -Arguments @(
+        "-c",
+        "import pandas, plotly, psutil, requests, streamlit; print('dashboard-extras-ok')"
+    )
+    $Summary["dependency_probe_exit_code"] = $DependencyResult.ExitCode
+    Assert-True -Condition ($DependencyResult.ExitCode -eq 0) -Message "The declared dashboard or monitoring extras are incomplete."
+
+    $StaticResult = Invoke-CapturedCommand -Name "local-entrypoint-contracts" -FilePath $VenvPython -Arguments @(
+        "-m", "pytest", "-q", "tests/test_local_entrypoint_contracts.py"
+    )
+    $Summary["static_contract_exit_code"] = $StaticResult.ExitCode
+    Assert-True -Condition ($StaticResult.ExitCode -eq 0) -Message "Local entrypoint contract tests failed on Windows."
+
+    $CompleteVenvBackup = Join-Path $RepoRoot ".venv-ci-complete"
+    if (Test-Path $CompleteVenvBackup) {
+        Remove-Item -LiteralPath $CompleteVenvBackup -Recurse -Force
+    }
+
+    Move-Item -LiteralPath $VenvDir -Destination $CompleteVenvBackup
+    try {
+        $MissingVenvResult = Invoke-LauncherExpectedFailure -Name "launcher-missing-venv" -ExpectedText "Virtual environment is missing"
+        $Summary["missing_venv_exit_code"] = $MissingVenvResult.ExitCode
+    }
+    finally {
+        if (Test-Path $VenvDir) {
+            Remove-Item -LiteralPath $VenvDir -Recurse -Force
+        }
+        Move-Item -LiteralPath $CompleteVenvBackup -Destination $VenvDir
+    }
+
+    $AppBackup = "$AppPath.ci-backup"
+    if (Test-Path $AppBackup) {
+        Remove-Item -LiteralPath $AppBackup -Force
+    }
+
+    Move-Item -LiteralPath $AppPath -Destination $AppBackup
+    try {
+        $MissingAppResult = Invoke-LauncherExpectedFailure -Name "launcher-missing-app" -ExpectedText "Dashboard entrypoint is missing"
+        $Summary["missing_app_exit_code"] = $MissingAppResult.ExitCode
+    }
+    finally {
+        if (Test-Path $AppPath) {
+            Remove-Item -LiteralPath $AppPath -Force
+        }
+        Move-Item -LiteralPath $AppBackup -Destination $AppPath
+    }
+
+    if (Test-Path $CompleteVenvBackup) {
+        Remove-Item -LiteralPath $CompleteVenvBackup -Recurse -Force
+    }
+
+    Move-Item -LiteralPath $VenvDir -Destination $CompleteVenvBackup
+    try {
+        $MinimalVenvResult = Invoke-CapturedCommand -Name "create-minimal-venv" -FilePath $BasePython -Arguments @(
+            "-m", "venv", $VenvDir
+        )
+        Assert-True -Condition ($MinimalVenvResult.ExitCode -eq 0) -Message "Unable to create the minimal virtual environment used for the missing-Streamlit test."
+
+        $MissingStreamlitResult = Invoke-LauncherExpectedFailure -Name "launcher-missing-streamlit" -ExpectedText "Streamlit is not installed"
+        $Summary["missing_streamlit_exit_code"] = $MissingStreamlitResult.ExitCode
+    }
+    finally {
+        if (Test-Path $VenvDir) {
+            Remove-Item -LiteralPath $VenvDir -Recurse -Force
+        }
+        Move-Item -LiteralPath $CompleteVenvBackup -Destination $VenvDir
+    }
+
+    Assert-True -Condition (Test-Path $VenvPython) -Message "The complete virtual environment was not restored after negative-path testing."
+    Assert-True -Condition (Test-Path $AppPath) -Message "The dashboard app was not restored after negative-path testing."
+
+    $env:STREAMLIT_SERVER_HEADLESS = "true"
+    $env:STREAMLIT_BROWSER_GATHER_USAGE_STATS = "false"
+    $env:STREAMLIT_SERVER_ADDRESS = "127.0.0.1"
+    $env:STREAMLIT_SERVER_PORT = "8501"
+    $env:STREAMLIT_SERVER_FILE_WATCHER_TYPE = "none"
+
+    $DashboardProcess = Start-Process -FilePath $WindowsPowerShell -ArgumentList @(
+        "-NoLogo",
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-File", $LauncherPath
+    ) -WorkingDirectory $RepoRoot -RedirectStandardOutput $DashboardStdout -RedirectStandardError $DashboardStderr -WindowStyle Hidden -PassThru
+
+    $Summary["dashboard_process_started"] = $true
+    Write-Host "[CI] Dashboard launcher PID: $($DashboardProcess.Id)"
+
+    $HealthUri = "http://127.0.0.1:8501/_stcore/health"
+    $RootUri = "http://127.0.0.1:8501/"
+    $Deadline = [DateTime]::UtcNow.AddSeconds(90)
+    $HealthResponse = $null
+
+    while ([DateTime]::UtcNow -lt $Deadline) {
+        $DashboardProcess.Refresh()
+        if ($DashboardProcess.HasExited) {
+            break
+        }
+
+        try {
+            $HealthResponse = Invoke-WebRequest -Uri $HealthUri -TimeoutSec 5
+            if ($HealthResponse.StatusCode -eq 200) {
+                break
+            }
+        }
+        catch {
+            Start-Sleep -Seconds 2
+        }
+    }
+
+    $DashboardProcess.Refresh()
+    if ($null -eq $HealthResponse -or $HealthResponse.StatusCode -ne 200) {
+        $StdoutText = if (Test-Path $DashboardStdout) { Get-Content -LiteralPath $DashboardStdout -Raw } else { "" }
+        $StderrText = if (Test-Path $DashboardStderr) { Get-Content -LiteralPath $DashboardStderr -Raw } else { "" }
+        throw "Dashboard health endpoint did not become ready. HasExited=$($DashboardProcess.HasExited)`nSTDOUT:`n$StdoutText`nSTDERR:`n$StderrText"
+    }
+
+    $Summary["dashboard_health_status"] = [int]$HealthResponse.StatusCode
+    $Summary["dashboard_health_body"] = $HealthResponse.Content.Trim()
+
+    $RootResponse = Invoke-WebRequest -Uri $RootUri -TimeoutSec 10
+    $Summary["dashboard_root_status"] = [int]$RootResponse.StatusCode
+    Assert-True -Condition ($RootResponse.StatusCode -eq 200) -Message "Dashboard root endpoint did not return HTTP 200."
+
+    Start-Sleep -Seconds 3
+    $DashboardProcess.Refresh()
+    Assert-True -Condition (-not $DashboardProcess.HasExited) -Message "Dashboard launcher exited immediately after reporting healthy."
+
+    Write-Host "DASHBOARD_PROCESS_STARTED=YES"
+    Write-Host "DASHBOARD_HEALTH_READY=YES"
+    Write-Host "DASHBOARD_HTTP_STATUS=$($HealthResponse.StatusCode)"
+
+    $Summary["status"] = "passed"
+}
+catch {
+    $Summary["status"] = "failed"
+    $Summary["failure_message"] = $_.Exception.Message
+    Write-Error $_
+    throw
+}
+finally {
+    if ($null -ne $DashboardProcess) {
+        try {
+            $DashboardProcess.Refresh()
+            if (-not $DashboardProcess.HasExited) {
+                $Taskkill = (Get-Command taskkill.exe -ErrorAction Stop).Source
+                $TaskkillResult = Invoke-CapturedCommand -Name "dashboard-process-tree-stop" -FilePath $Taskkill -Arguments @(
+                    "/PID", [string]$DashboardProcess.Id,
+                    "/T",
+                    "/F"
+                )
+                if ($TaskkillResult.ExitCode -ne 0) {
+                    Write-Warning "taskkill returned exit code $($TaskkillResult.ExitCode)."
+                }
+            }
+
+            $null = $DashboardProcess.WaitForExit(15000)
+            $DashboardProcess.Refresh()
+            $Summary["dashboard_process_stopped"] = $DashboardProcess.HasExited
+        }
+        catch {
+            Write-Warning "Unable to confirm dashboard process cleanup: $($_.Exception.Message)"
+            $Summary["dashboard_process_stopped"] = $false
+        }
+    }
+
+    if ($Summary["dashboard_process_started"] -and $Summary["dashboard_process_stopped"]) {
+        Write-Host "DASHBOARD_PROCESS_STOPPED=YES"
+    }
+
+    $Summary["finished_at_utc"] = [DateTime]::UtcNow.ToString("o")
+    $SummaryPath = Join-Path $ArtifactDirectory "summary.json"
+    $Summary | ConvertTo-Json -Depth 6 | Set-Content -Path $SummaryPath -Encoding UTF8
+    Write-Host "[CI] Readback summary: $SummaryPath"
+}

--- a/setup_env.ps1
+++ b/setup_env.ps1
@@ -3,50 +3,106 @@ $ErrorActionPreference = "Stop"
 $env:PYTHONUTF8 = "1"
 $env:PYTHONIOENCODING = "utf-8"
 
-Write-Host "[ToneSoul] Environment Setup" -ForegroundColor Cyan
-Write-Host "Rebuilding virtual environment in Root..." -ForegroundColor Gray
+Set-Location $PSScriptRoot
 
-# 1. Check Global Python (python → python3 → py launcher)
-$GlobalPy = $null
-foreach ($cmd in @("python", "python3", "py")) {
-    try {
-        $GlobalPy = Get-Command $cmd -ErrorAction Stop
-        Write-Host "Found Global Python: $($GlobalPy.Source)" -ForegroundColor Green
-        break
+Write-Host "[ToneSoul] Environment Setup" -ForegroundColor Cyan
+Write-Host "Repository Root: $PSScriptRoot" -ForegroundColor Gray
+
+function Resolve-PythonCommand {
+    $candidates = @(
+        @{ Name = "python"; Args = @() },
+        @{ Name = "python3"; Args = @() },
+        @{ Name = "py"; Args = @("-3") }
+    )
+
+    foreach ($candidate in $candidates) {
+        try {
+            $candidateName = [string]$candidate.Name
+            $null = Get-Command $candidateName -ErrorAction Stop
+            [string[]]$candidateArgs = $candidate.Args
+            $versionText = & $candidateName @candidateArgs -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
+
+            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($versionText)) {
+                continue
+            }
+
+            $parts = $versionText.Trim().Split(".")
+            if ($parts.Count -lt 2) {
+                continue
+            }
+
+            $major = [int]$parts[0]
+            $minor = [int]$parts[1]
+            if (($major -gt 3) -or ($major -eq 3 -and $minor -ge 10)) {
+                return [PSCustomObject]@{
+                    Name = $candidateName
+                    Args = $candidate.Args
+                    Version = $versionText.Trim()
+                }
+            }
+
+            $message = "Skipping {0}: Python {1} is below the required 3.10." -f $candidateName, $versionText.Trim()
+            Write-Host $message -ForegroundColor Yellow
+        }
+        catch {
+            continue
+        }
     }
-    catch { continue }
+
+    return $null
 }
-if ($null -eq $GlobalPy) {
-    Write-Host "[Error] No global python found! Tried: python, python3, py" -ForegroundColor Red
-    Write-Host "Please install Python 3.10+ and add to PATH." -ForegroundColor Red
-    Read-Host "Press Enter to exit"
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Command,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    & $Command @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Label failed with exit code $LASTEXITCODE."
+    }
+}
+
+$Python = Resolve-PythonCommand
+if ($null -eq $Python) {
+    Write-Host "[Error] Python 3.10+ was not found." -ForegroundColor Red
+    Write-Host "Tried: python, python3, and py -3." -ForegroundColor Red
     exit 1
 }
 
-# 2. Create Venv
-$VenvDir = ".\.venv"
-if (Test-Path $VenvDir) {
-    Write-Host "Existing .venv found. Re-using..." -ForegroundColor Yellow
+Write-Host ("Found Python {0} via {1}." -f $Python.Version, $Python.Name) -ForegroundColor Green
+
+$VenvDir = Join-Path $PSScriptRoot ".venv"
+$VenvPython = Join-Path $VenvDir "Scripts\python.exe"
+
+if (-not (Test-Path $VenvPython)) {
+    Write-Host "Creating .venv..." -ForegroundColor Cyan
+    [string[]]$venvArgs = @($Python.Args) + @("-m", "venv", $VenvDir)
+    Invoke-Checked -Label "Virtual environment creation" -Command $Python.Name -Arguments $venvArgs
 }
 else {
-    Write-Host "Creating .venv..." -ForegroundColor Cyan
-    & $GlobalPy.Name -m venv .venv
+    Write-Host "Existing .venv found. Re-using it." -ForegroundColor Yellow
 }
 
-# 3. Verify Venv Creation
-$VenvPython = ".\.venv\Scripts\python.exe"
 if (-not (Test-Path $VenvPython)) {
-    Write-Host "[Error] Failed to create .venv!" -ForegroundColor Red
-    Read-Host "Press Enter to exit"
+    Write-Host "[Error] .venv was not created successfully." -ForegroundColor Red
     exit 1
 }
 
-# 4. Install Dependencies
-Write-Host "Installing Dependencies..." -ForegroundColor Cyan
-& $VenvPython -m pip install --upgrade pip
-& $VenvPython -m pip install -r requirements.txt
-& $VenvPython -m pip install streamlit plotly pandas psutil requests
+Invoke-Checked -Label "Virtual environment validation" -Command $VenvPython -Arguments @(
+    "-c",
+    "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)"
+)
 
-Write-Host "Setup Complete!" -ForegroundColor Green
-Write-Host "You can now run: .\start_dashboard.bat" -ForegroundColor Cyan
-Read-Host "Press Enter to exit"
+Write-Host "Installing editable dependencies from pyproject.toml..." -ForegroundColor Cyan
+Invoke-Checked -Label "pip upgrade" -Command $VenvPython -Arguments @(
+    "-m", "pip", "install", "--upgrade", "pip"
+)
+Invoke-Checked -Label "ToneSoul dependency installation" -Command $VenvPython -Arguments @(
+    "-m", "pip", "install", "-e", ".[dev,dashboard,monitoring]"
+)
+
+Write-Host "Setup complete." -ForegroundColor Green
+Write-Host "Run: .\start_dashboard.bat" -ForegroundColor Cyan

--- a/start_dashboard.ps1
+++ b/start_dashboard.ps1
@@ -1,31 +1,37 @@
 $ErrorActionPreference = "Stop"
-
-# 1. Setup
-$ErrorActionPreference = "Continue" # Don't stop on minor errors
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$env:PYTHONUTF8 = "1"
+$env:PYTHONIOENCODING = "utf-8"
 
-Write-Host "[ToneSoul] Dashboard Launcher (Blind Mode)" -ForegroundColor Cyan
-$CurrentDir = Get-Location
-Write-Host "Working Dir: $CurrentDir" -ForegroundColor Gray
+Set-Location $PSScriptRoot
 
-# 2. Define Python Path (Root Relative)
-# Since we flattened the repo, .venv is in the same folder!
-$VenvPython = ".\.venv\Scripts\python.exe"
+Write-Host "[ToneSoul] Dashboard Launcher" -ForegroundColor Cyan
+Write-Host "Repository Root: $PSScriptRoot" -ForegroundColor Gray
 
-Write-Host "Target Python: $VenvPython" -ForegroundColor Gray
-Write-Host "Mode: Clean Root Structure" -ForegroundColor Green
-Write-Host "Skipping specific path checks to avoid unicode issues (Blind Trust)" -ForegroundColor Yellow
+$VenvPython = Join-Path $PSScriptRoot ".venv\Scripts\python.exe"
+$AppPath = Join-Path $PSScriptRoot "apps\dashboard\frontend\app.py"
 
-# 3. Launch
-$AppPath = "apps\dashboard\frontend\app.py"
-Write-Host "Launching..." -ForegroundColor Green
+if (-not (Test-Path $VenvPython)) {
+    Write-Host "[Error] Virtual environment is missing: $VenvPython" -ForegroundColor Red
+    Write-Host "Run .\setup_env.bat first." -ForegroundColor Yellow
+    exit 1
+}
 
-# Invoke directly
+if (-not (Test-Path $AppPath)) {
+    Write-Host "[Error] Dashboard entrypoint is missing: $AppPath" -ForegroundColor Red
+    exit 1
+}
+
+& $VenvPython -c "import streamlit"
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "[Error] Streamlit is not installed in .venv." -ForegroundColor Red
+    Write-Host "Run .\setup_env.bat to restore the declared dashboard extras." -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "Launching dashboard..." -ForegroundColor Green
 & $VenvPython -m streamlit run $AppPath
-
-if ($LastExitCode -ne 0) {
-    Write-Host "Exit Code: $LastExitCode" -ForegroundColor Red
-    Write-Host "If this failed, please manually run:"
-    Write-Host "..\.venv\Scripts\python.exe -m streamlit run apps\dashboard\frontend\app.py"
-    Read-Host "Press Enter to exit"
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "[Error] Dashboard exited with code $LASTEXITCODE." -ForegroundColor Red
+    exit $LASTEXITCODE
 }

--- a/tests/test_local_entrypoint_contracts.py
+++ b/tests/test_local_entrypoint_contracts.py
@@ -1,0 +1,61 @@
+"""Static contracts for cross-platform local setup entrypoints."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _capture(pattern: str, text: str, label: str) -> str:
+    match = re.search(pattern, text, flags=re.MULTILINE)
+    assert match is not None, f"Unable to locate {label}"
+    return match.group(1)
+
+
+def test_package_version_matches_project_metadata() -> None:
+    pyproject = _read("pyproject.toml")
+    package_init = _read("tonesoul/__init__.py")
+
+    project_version = _capture(r'^version = "([^"]+)"$', pyproject, "project version")
+    package_version = _capture(
+        r'^__version__ = "([^"]+)"$', package_init, "package version"
+    )
+
+    assert package_version == project_version
+
+
+def test_windows_setup_uses_pyproject_as_dependency_source() -> None:
+    setup = _read("setup_env.ps1")
+
+    assert '"-e", ".[dev,dashboard,monitoring]"' in setup
+    assert "pip install -r requirements.txt" not in setup
+    assert "streamlit plotly pandas psutil requests" not in setup
+    assert "Python 3.10+" in setup
+    assert '@{ Name = "py"; Args = @("-3") }' in setup
+
+
+def test_unix_installer_verifies_the_installed_distribution() -> None:
+    installer = _read("install.sh")
+
+    assert "set -euo pipefail" in installer
+    assert 'version("tonesoul52")' in installer
+    assert "package_version = tonesoul.__version__" in installer
+    assert '|| echo "ToneSoul core installed"' not in installer
+    assert "curl -sSL" not in installer
+
+
+def test_dashboard_launcher_fails_closed_on_missing_inputs() -> None:
+    launcher = _read("start_dashboard.ps1")
+
+    assert "Set-Location $PSScriptRoot" in launcher
+    assert "Test-Path $VenvPython" in launcher
+    assert "Test-Path $AppPath" in launcher
+    assert '$ErrorActionPreference = "Continue"' not in launcher
+    assert "Blind Trust" not in launcher
+    assert "Blind Mode" not in launcher

--- a/tests/test_local_entrypoint_contracts.py
+++ b/tests/test_local_entrypoint_contracts.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -48,6 +50,14 @@ def test_unix_installer_verifies_the_installed_distribution() -> None:
     assert "package_version = tonesoul.__version__" in installer
     assert '|| echo "ToneSoul core installed"' not in installer
     assert "curl -sSL" not in installer
+
+
+def test_unix_installer_has_valid_bash_syntax() -> None:
+    bash = shutil.which("bash")
+    if bash is None:
+        return
+
+    subprocess.run([bash, "-n", str(ROOT / "install.sh")], check=True)
 
 
 def test_dashboard_launcher_fails_closed_on_missing_inputs() -> None:

--- a/tests/test_local_entrypoint_contracts.py
+++ b/tests/test_local_entrypoint_contracts.py
@@ -69,3 +69,29 @@ def test_dashboard_launcher_fails_closed_on_missing_inputs() -> None:
     assert '$ErrorActionPreference = "Continue"' not in launcher
     assert "Blind Trust" not in launcher
     assert "Blind Mode" not in launcher
+
+
+def test_windows_workflow_checks_out_and_runs_the_exact_pr_head() -> None:
+    workflow = _read(".github/workflows/windows-local-entrypoints.yml")
+
+    assert "runs-on: windows-latest" in workflow
+    assert "timeout-minutes: 30" in workflow
+    assert "github.event.pull_request.head.sha || github.sha" in workflow
+    assert "verify_windows_entrypoints.ps1" in workflow
+    assert "actions/upload-artifact@v4" in workflow
+    assert "if-no-files-found: error" in workflow
+
+
+def test_windows_runtime_harness_covers_success_failure_and_cleanup() -> None:
+    harness = _read("scripts/ci/verify_windows_entrypoints.ps1")
+
+    assert "setup_env.ps1" in harness
+    assert "start_dashboard.ps1" in harness
+    assert "launcher-missing-venv" in harness
+    assert "launcher-missing-app" in harness
+    assert "launcher-missing-streamlit" in harness
+    assert "/_stcore/health" in harness
+    assert "dashboard_root_status" in harness
+    assert "Stop-DashboardProcessTree" in harness
+    assert "DASHBOARD_PROCESS_STOPPED=YES" in harness
+    assert "summary.json" in harness


### PR DESCRIPTION
## What changed

- Align the Windows bootstrap with `pyproject.toml` as the dependency source of truth.
- Probe `python`, `python3`, and `py -3` by actually executing them and require Python 3.10+ before creating the virtual environment.
- Install the declared Windows dashboard profile through editable extras: `dev`, `dashboard`, and `monitoring`.
- Replace the Windows dashboard launcher's blind-trust path with explicit `.venv`, entrypoint, and Streamlit preflight checks.
- Make the Linux/macOS installer operate from a local checkout, use the virtual environment interpreter directly, and verify that package and distribution versions agree.
- Add static regression contracts for version parity, dependency-source alignment, fail-closed launch behavior, and Bash syntax.
- Add a dedicated `windows-latest` workflow and runtime readback harness for PowerShell setup, negative-path behavior, Streamlit health, HTTP reachability, and process-tree cleanup.

## Why

The existing local entrypoints had diverged across hosts:

- Windows installed from `requirements.txt` and then manually added packages even though `pyproject.toml` is declared canonical.
- The dashboard launcher suppressed useful preflight failures and relied on blind path assumptions.
- The Unix installer advertised a piped remote install while executing as though it were already inside a checkout, and its installation check could fall through to a success-looking message.
- Static review alone could not prove that the patched Windows path actually created a usable environment, failed closed, started Streamlit, returned HTTP health, and cleaned up its process tree.

This patch keeps host-specific mechanics in the entrypoint layer while preserving the same package contract and version identity.

## Validation

### Portable/static contracts

- `bash -n install.sh`
- `pytest -q tests/test_local_entrypoint_contracts.py`
- Windows execution result at head `8214ec00630437946c35141f14ace291e55bb215`: `7 passed`

### Windows runner readback

Environment:

- Runner: Microsoft Windows Server 2025
- Windows PowerShell: `5.1.26100.32995`
- Python / generated venv: `3.12.10`

Observed results:

- `setup_env.ps1`: exit `0`
- Declared dashboard/monitoring dependency probe: exit `0`
- Missing `.venv`: exit `1`, expected fail-closed message observed
- Missing dashboard `app.py`: exit `1`, expected fail-closed message observed
- Missing Streamlit: exit `1`, expected fail-closed message observed
- Dashboard process started: `true`
- `/_stcore/health`: HTTP `200`, body `ok`
- Dashboard root: HTTP `200`
- Dashboard process tree stopped: `true`

Readback artifact:

- `windows-entrypoint-readback-1`
- SHA-256 digest: `ae813e0d8e522ba6f528a4ffcd88d117ddb79e99b8fd2b376235847890e92828`

### Required checks

- Critical Path Tests: success
- Repo Healthcheck: success
- Windows Local Entrypoint Validation: success

## Boundaries

- No MirrorTone/ToneSoul governance semantics changed.
- No route, evidence, rollback, completion, or release-gate semantics changed.
- This supports a claim of cross-platform local-entrypoint validation for this exact PR head.
- It does not claim every end-user Windows desktop configuration, the full runtime, or a production release has been validated.